### PR TITLE
Fix deprecated None value to blank str

### DIFF
--- a/4subsea.mplstyle
+++ b/4subsea.mplstyle
@@ -12,7 +12,7 @@ axes.labelsize : medium
 axes.formatter.limits : -4, 4
 axes.formatter.use_mathtext : True
 axes.formatter.useoffset : False
-axes.prop_cycle : cycler('marker', [None, 'o', 'D', 's', '^']) * cycler('linestyle', ['-', '--', '-.', ':']) * cycler('color', ['012b5d', 'faa634', '00a0b0', 'ed174f', '716fb3'])                                            # color cycle for plot lines
+axes.prop_cycle : cycler('marker', ['', 'o', 'D', 's', '^']) * cycler('linestyle', ['-', '--', '-.', ':']) * cycler('color', ['012b5d', 'faa634', '00a0b0', 'ed174f', '716fb3'])                                            # color cycle for plot lines
                                             
 ### LINES
 lines.linewidth : 1.5

--- a/4subsea_presentation.mplstyle
+++ b/4subsea_presentation.mplstyle
@@ -12,7 +12,7 @@ axes.labelsize : medium
 axes.formatter.limits : -4, 4
 axes.formatter.use_mathtext : True
 axes.formatter.useoffset : False
-axes.prop_cycle : cycler('marker', [None, 'o', 'D', 's', '^']) * cycler('linestyle', ['-', '--', '-.', ':']) * cycler('color', ['012b5d', 'faa634', '00a0b0', 'ed174f', '716fb3'])                          
+axes.prop_cycle : cycler('marker', ['', 'o', 'D', 's', '^']) * cycler('linestyle', ['-', '--', '-.', ':']) * cycler('color', ['012b5d', 'faa634', '00a0b0', 'ed174f', '716fb3'])                          
 
 ### LINES
 lines.linewidth : 2.

--- a/4subsea_presentation_additional_colors.mplstyle
+++ b/4subsea_presentation_additional_colors.mplstyle
@@ -12,7 +12,7 @@ axes.labelsize : medium
 axes.formatter.limits : -4, 4
 axes.formatter.use_mathtext : True
 axes.formatter.useoffset : False
-axes.prop_cycle : cycler('marker', [None, 'o', 'D', 's', '^']) * cycler('linestyle', ['-', '--', '-.', ':']) * cycler('color', ['012b5d', 'faa634', '00a0b0', 'ed174f', '716fb3','009ddc','f3776f','f16d9a'])                          
+axes.prop_cycle : cycler('marker', ['', 'o', 'D', 's', '^']) * cycler('linestyle', ['-', '--', '-.', ':']) * cycler('color', ['012b5d', 'faa634', '00a0b0', 'ed174f', '716fb3','009ddc','f3776f','f16d9a'])                          
 
 ### LINES
 lines.linewidth : 2.


### PR DESCRIPTION
Matplotlib 3.5 introduced a deprecation warning that rcParams that expected a string must be given as a string. This PR seeks to change the `None` value to simply `""` as that is given as an example in the [documentation](https://matplotlib.org/stable/api/markers_api.html) as a measure to avoid this warning. The new value has been a valid value for many versions (at least since matplotlib 2.2, so this change should not affect any existing code running with older version of matplotlib in 4Subsea.