### PR TITLE
fix: use 'none' instead of ''

### DIFF
--- a/4subsea.mplstyle
+++ b/4subsea.mplstyle
@@ -12,7 +12,7 @@ axes.labelsize : medium
 axes.formatter.limits : -4, 4
 axes.formatter.use_mathtext : True
 axes.formatter.useoffset : False
-axes.prop_cycle : cycler('marker', ['', 'o', 'D', 's', '^']) * cycler('linestyle', ['-', '--', '-.', ':']) * cycler('color', ['012b5d', 'faa634', '00a0b0', 'ed174f', '716fb3'])                                            # color cycle for plot lines
+axes.prop_cycle : cycler('marker', ['none', 'o', 'D', 's', '^']) * cycler('linestyle', ['-', '--', '-.', ':']) * cycler('color', ['012b5d', 'faa634', '00a0b0', 'ed174f', '716fb3'])                                            # color cycle for plot lines
                                             
 ### LINES
 lines.linewidth : 1.5

--- a/4subsea_presentation.mplstyle
+++ b/4subsea_presentation.mplstyle
@@ -12,7 +12,7 @@ axes.labelsize : medium
 axes.formatter.limits : -4, 4
 axes.formatter.use_mathtext : True
 axes.formatter.useoffset : False
-axes.prop_cycle : cycler('marker', ['', 'o', 'D', 's', '^']) * cycler('linestyle', ['-', '--', '-.', ':']) * cycler('color', ['012b5d', 'faa634', '00a0b0', 'ed174f', '716fb3'])                          
+axes.prop_cycle : cycler('marker', ['none', 'o', 'D', 's', '^']) * cycler('linestyle', ['-', '--', '-.', ':']) * cycler('color', ['012b5d', 'faa634', '00a0b0', 'ed174f', '716fb3'])                          
 
 ### LINES
 lines.linewidth : 2.

--- a/4subsea_presentation_additional_colors.mplstyle
+++ b/4subsea_presentation_additional_colors.mplstyle
@@ -12,7 +12,7 @@ axes.labelsize : medium
 axes.formatter.limits : -4, 4
 axes.formatter.use_mathtext : True
 axes.formatter.useoffset : False
-axes.prop_cycle : cycler('marker', ['', 'o', 'D', 's', '^']) * cycler('linestyle', ['-', '--', '-.', ':']) * cycler('color', ['012b5d', 'faa634', '00a0b0', 'ed174f', '716fb3','009ddc','f3776f','f16d9a'])                          
+axes.prop_cycle : cycler('marker', ['none', 'o', 'D', 's', '^']) * cycler('linestyle', ['-', '--', '-.', ':']) * cycler('color', ['012b5d', 'faa634', '00a0b0', 'ed174f', '716fb3','009ddc','f3776f','f16d9a'])                          
 
 ### LINES
 lines.linewidth : 2.


### PR DESCRIPTION
Fixes last PR.

Setting `marker=""` is fine when used in `plt.plot`, but stylesheets use `cycler`. `cycler` ignores "" and jumps to next item. Replaced with "none" instead.